### PR TITLE
fix TypeError in LibertyTracker

### DIFF
--- a/alphazero/go.py
+++ b/alphazero/go.py
@@ -2,9 +2,9 @@
 
 # %% auto 0
 __all__ = ['N', 'WHITE', 'EMPTY', 'BLACK', 'FILL', 'KO', 'UNKNOWN', 'MISSING_GROUP_ID', 'ALL_COORDS', 'EMPTY_BOARD', 'NEIGHBORS',
-           'DIAGONALS', 'IllegalMove', 'PlayerMove', 'PositionWithContext', 'place_stones', 'replace_position',
-           'find_reached', 'is_koish', 'is_eyeish', 'Group', 'LibertyTracker', 'Position', 'from_flat', 'to_flat',
-           'from_sgf', 'to_sgf', 'from_gtp', 'to_gtp']
+           'DIAGONALS', 'from_flat', 'to_flat', 'from_sgf', 'to_sgf', 'from_gtp', 'to_gtp', 'IllegalMove', 'PlayerMove',
+           'PositionWithContext', 'place_stones', 'replace_position', 'find_reached', 'is_koish', 'is_eyeish', 'Group',
+           'LibertyTracker', 'Position']
 
 # %% ../go.ipynb 5
 import numpy as np
@@ -13,17 +13,63 @@ import copy
 import itertools
 import os
 
-# %% ../go.ipynb 6
+# %% ../go.ipynb 10
+_SGF_COLUMNS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+_GTP_COLUMNS = 'ABCDEFGHJKLMNOPQRSTUVWXYZ'
+
+# %% ../go.ipynb 11
+def from_flat(flat):
+    """Converts from a flattened coordinate to a Go coordinate"""
+    if flat == N * N: # go.N
+        return None
+    return divmod(flat, N)
+
+def to_flat(coord):
+    """Converts from a Go coordinate to a flattened coordinate."""
+    if coord is None:
+        return N * N # go.N
+    return N * coord[0] + coord[1]
+
+def from_sgf(sgfc):
+    """Converts from an SGF coordinate to a Go coordinate."""
+    if sgfc is None or sgfc == '' or (N <= 19 and sgfc == 'tt'): # go.N
+        return None
+    return _SGF_COLUMNS.index(sgfc[1]), _SGF_COLUMNS.index(sgfc[0])
+
+def to_sgf(coord):
+    """Converts from a Go coordinate to an SGF coordinate."""
+    if coord is None:
+        return ''
+    return _SGF_COLUMNS[coord[1]] + _SGF_COLUMNS[coord[0]]
+
+def from_gtp(gtpc):
+    """Converts from a GTP coordinate to a Go coordinate."""
+    gtpc = gtpc.upper()
+    if gtpc == 'PASS':
+        return None
+    col = _GTP_COLUMNS.index(gtpc[0])
+    row_from_bottom = int(gtpc[1:])
+    return N - row_from_bottom, col # go.N
+
+def to_gtp(coord):
+    """Converts from a Go coordinate to a GTP coordinate."""
+    if coord is None:
+        return 'pass'
+    y,x = coord
+    return f'{_GTP_COLUMNS[x]}{N-y}'
+
+
+# %% ../go.ipynb 13
 # size of the game board
 N = int(os.environ.get('BOARD_SIZE', 19))
 
-# %% ../go.ipynb 8
+# %% ../go.ipynb 15
 WHITE, EMPTY, BLACK, FILL, KO, UNKNOWN = range(-1, 5)
 
-# %% ../go.ipynb 10
+# %% ../go.ipynb 17
 MISSING_GROUP_ID = -1
 
-# %% ../go.ipynb 11
+# %% ../go.ipynb 18
 ALL_COORDS = [(i,j) for i in range(N) for j in range(N)]
 EMPTY_BOARD = np.zeros((N,N), dtype=np.int8)
 
@@ -34,12 +80,12 @@ NEIGHBORS = {(x,y): list(filter(_check_bounds, [
 DIAGONALS = {(x,y): list(filter(_check_bounds, [
     (x+1, y+1), (x+1, y-1), (x-1, y+1), (x-1, y-1)])) for x, y in ALL_COORDS}
 
-# %% ../go.ipynb 12
+# %% ../go.ipynb 19
 class IllegalMove(Exception): pass
 class PlayerMove(namedtuple('PlayerMove', ['color','move'])): pass
 class PositionWithContext(namedtuple('SgfPosition', ['position', 'next_move', 'result'])): pass
 
-# %% ../go.ipynb 13
+# %% ../go.ipynb 20
 def place_stones(board, color, stones): 
     for s in stones: board[s] = color
 
@@ -111,7 +157,7 @@ def is_eyeish(board, c):
     else:
         return color
 
-# %% ../go.ipynb 14
+# %% ../go.ipynb 21
 class Group(namedtuple('Group', ['id','stones','liberties','color'])):
     """
      
@@ -123,7 +169,7 @@ class Group(namedtuple('Group', ['id','stones','liberties','color'])):
         return self.stones == other.stones and self.liberties == other.liberties and self.color == other.color
     
 
-# %% ../go.ipynb 16
+# %% ../go.ipynb 23
 class LibertyTracker():
     @staticmethod
     def from_board(board):
@@ -160,7 +206,7 @@ class LibertyTracker():
                  liberty_cache:np.ndarray=None, # an NxN numpy array of liberty counts.
                  max_group_id:int=1):
         """
-        Tracks liberties -- number of free positions around a collective unit.
+        Tracks liberties -- number of free positions around a collective unit. Used for calculating captures.
 
         group index: an NxN numpy array of group_ids. -1: no group.
         groups: a dict of group_id:groups
@@ -251,6 +297,7 @@ class LibertyTracker():
 
     def _update_liberties(self, group_id, add=set(), remove=set()):
         group = self.groups[group_id]
+        if type(remove) == tuple: remove = set(remove) # prevents TypeError when subtracting frozenset – tuple in: `new_libs = (group.liberties | add) - remove`
         new_libs = (group.liberties | add) - remove
         self.groups[group_id] = Group(group_id, group.stones, new_libs, group.color)
 
@@ -265,7 +312,7 @@ class LibertyTracker():
                 if group_id != MISSING_GROUP_ID:
                     self._update_liberties(group_id, add={s})
 
-# %% ../go.ipynb 25
+# %% ../go.ipynb 32
 class Position():
     def __init__(self, 
                  board:np.ndarray=None, # numpy array
@@ -411,7 +458,7 @@ class Position():
         # pass is always invalid
         return np.concatenate([legal_moves.ravel(), [1]])
 
-    def pass_move(self, mutate=False):
+    def pass_move(self, mutate:bool=False): # modifies in place if `True`
         pos = self if mutate else copy.deepcopy(self)
         pos.n += 1
         pos.recent += (PlayerMove(pos.to_play, None),)
@@ -422,7 +469,7 @@ class Position():
         pos.ko = None
         return pos
 
-    def flip_playerturn(self, mutate=False):
+    def flip_playerturn(self, mutate:bool=False): # modifies in place if `True`
         """Returns a copy of the `Position` object with `to_play`'s sign flipped."""
         pos = self if mutate else copy.deepcopy(self)
         pos.ko = None
@@ -432,7 +479,7 @@ class Position():
     def get_liberties(self):
         return self.lib_tracker.liberty_cache
 
-    def play_move(self, c, color=None, mutate=False):
+    def play_move(self, c, color=None, mutate:bool=False): # modifies in place if `True`
         """
         Obeys [CGOS Rules of Play](http://www.yss-aya.com/cgos/): No suicides, Chinese/area scoring, Positional superko (this is approximated in this implementation).
 
@@ -450,6 +497,7 @@ class Position():
             pos = pos.pass_move(mutate=mutate)
             return pos
 
+        # only displays current player color, ignores color argument
         if not self.is_move_legal(c):
             raise IllegalMove(f"{'Black' if self.to_play == BLACK else 'White'} move at {to_gtp(c)} is invalid: \n{self}") # coords.to_gtp
 
@@ -528,50 +576,4 @@ class Position():
             return f"W+{abs(score):.1f}"
         else:
             return 'DRAW'
-
-
-# %% ../go.ipynb 63
-_SGF_COLUMNS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
-_GTP_COLUMNS = 'ABCDEFGHJKLMNOPQRSTUVWXYZ'
-
-# %% ../go.ipynb 64
-def from_flat(flat):
-    """Converts from a flattened coordinate to a Go coordinate"""
-    if flat == N * N: # go.N
-        return None
-    return divmod(flat, N)
-
-def to_flat(coord):
-    """Converts from a Go coordinate to a flattened coordinate."""
-    if coord is None:
-        return N * N # go.N
-    return N * coord[0] + coord[1]
-
-def from_sgf(sgfc):
-    """Converts from an SGF coordinate to a Go coordinate."""
-    if sgfc is None or sgfc == '' or (N <= 19 and sgfc == 'tt'): # go.N
-        return None
-    return _SGF_COLUMNS.index(sgfc[1]), _SGF_COLUMNS.index(sgfc[0])
-
-def to_sgf(coord):
-    """Converts from a Go coordinate to an SGF coordinate."""
-    if coord is None:
-        return ''
-    return _SGF_COLUMNS[coord[1]] + _SGF_COLUMNS[coord[0]]
-
-def from_gtp(gtpc):
-    """Converts from a GTP coordinate to a Go coordinate."""
-    gtpc = gtpc.upper()
-    if gtpc == 'PASS':
-        return None
-    col = _GTP_COLUMNS.index(gtpc[0])
-    row_from_bottom = int(gtpc[1:])
-    return N - row_from_bottom, col # go.N
-
-def to_gtp(coord):
-    """Converts from a Go coordinate to a GTP coordinate."""
-    if coord is None:
-        return 'pass'
-    y,x = coord
-    return f'{_GTP_COLUMNS[x]}{N-y}'
 

--- a/go.ipynb
+++ b/go.ipynb
@@ -32,7 +32,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This code is adapted from https://github.com/tensorflow/minigo/blob/master/go.py, commit [7b44376](https://github.com/tensorflow/minigo/commit/7b44376c4266ed41ba397dfe79ba87f040c0e35f), under the Apache 2.0 license."
+    "This code is adapted from [minigo/go](https://github.com/tensorflow/minigo/blob/master/go.py), commit [7b44376](https://github.com/tensorflow/minigo/commit/7b44376c4266ed41ba397dfe79ba87f040c0e35f), under the Apache 2.0 license."
    ]
   },
   {
@@ -60,6 +60,98 @@
     "import copy\n",
     "import itertools\n",
     "import os"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Go Coordinate Helpers"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This code is adapted from [minigo/coords](https://github.com/tensorflow/minigo/blob/master/coords.py), commit [ac169db](https://github.com/tensorflow/minigo/commit/ac169db7e002c152489615dd45f06c5ba7ee77fc), under the Apache 2.0 license."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "More than 19 entries are provided, for boards larger than 19x19."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#| export\n",
+    "_SGF_COLUMNS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'\n",
+    "_GTP_COLUMNS = 'ABCDEFGHJKLMNOPQRSTUVWXYZ'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#| export\n",
+    "def from_flat(flat):\n",
+    "    \"\"\"Converts from a flattened coordinate to a Go coordinate\"\"\"\n",
+    "    if flat == N * N: # go.N\n",
+    "        return None\n",
+    "    return divmod(flat, N)\n",
+    "\n",
+    "def to_flat(coord):\n",
+    "    \"\"\"Converts from a Go coordinate to a flattened coordinate.\"\"\"\n",
+    "    if coord is None:\n",
+    "        return N * N # go.N\n",
+    "    return N * coord[0] + coord[1]\n",
+    "\n",
+    "def from_sgf(sgfc):\n",
+    "    \"\"\"Converts from an SGF coordinate to a Go coordinate.\"\"\"\n",
+    "    if sgfc is None or sgfc == '' or (N <= 19 and sgfc == 'tt'): # go.N\n",
+    "        return None\n",
+    "    return _SGF_COLUMNS.index(sgfc[1]), _SGF_COLUMNS.index(sgfc[0])\n",
+    "\n",
+    "def to_sgf(coord):\n",
+    "    \"\"\"Converts from a Go coordinate to an SGF coordinate.\"\"\"\n",
+    "    if coord is None:\n",
+    "        return ''\n",
+    "    return _SGF_COLUMNS[coord[1]] + _SGF_COLUMNS[coord[0]]\n",
+    "\n",
+    "def from_gtp(gtpc):\n",
+    "    \"\"\"Converts from a GTP coordinate to a Go coordinate.\"\"\"\n",
+    "    gtpc = gtpc.upper()\n",
+    "    if gtpc == 'PASS':\n",
+    "        return None\n",
+    "    col = _GTP_COLUMNS.index(gtpc[0])\n",
+    "    row_from_bottom = int(gtpc[1:])\n",
+    "    return N - row_from_bottom, col # go.N\n",
+    "\n",
+    "def to_gtp(coord):\n",
+    "    \"\"\"Converts from a Go coordinate to a GTP coordinate.\"\"\"\n",
+    "    if coord is None:\n",
+    "        return 'pass'\n",
+    "    y,x = coord\n",
+    "    return f'{_GTP_COLUMNS[x]}{N-y}'\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Go State Engine"
    ]
   },
   {
@@ -287,7 +379,7 @@
     "                 liberty_cache:np.ndarray=None, # an NxN numpy array of liberty counts.\n",
     "                 max_group_id:int=1):\n",
     "        \"\"\"\n",
-    "        Tracks liberties -- number of free positions around a collective unit.\n",
+    "        Tracks liberties -- number of free positions around a collective unit. Used for calculating captures.\n",
     "\n",
     "        group index: an NxN numpy array of group_ids. -1: no group.\n",
     "        groups: a dict of group_id:groups\n",
@@ -378,6 +470,7 @@
     "\n",
     "    def _update_liberties(self, group_id, add=set(), remove=set()):\n",
     "        group = self.groups[group_id]\n",
+    "        if type(remove) == tuple: remove = set(remove) # prevents TypeError when subtracting frozenset – tuple in: `new_libs = (group.liberties | add) - remove`\n",
     "        new_libs = (group.liberties | add) - remove\n",
     "        self.groups[group_id] = Group(group_id, group.stones, new_libs, group.color)\n",
     "\n",
@@ -437,7 +530,7 @@
        ">                               liberty_cache:numpy.ndarray=None,\n",
        ">                               max_group_id:int=1)\n",
        "\n",
-       "Tracks liberties -- number of free positions around a collective unit.\n",
+       "Tracks liberties -- number of free positions around a collective unit. Used for calculating captures.\n",
        "\n",
        "|    | **Type** | **Default** | **Details** |\n",
        "| -- | -------- | ----------- | ----------- |\n",
@@ -773,7 +866,7 @@
     "        # pass is always invalid\n",
     "        return np.concatenate([legal_moves.ravel(), [1]])\n",
     "\n",
-    "    def pass_move(self, mutate=False):\n",
+    "    def pass_move(self, mutate:bool=False): # modifies in place if `True`\n",
     "        pos = self if mutate else copy.deepcopy(self)\n",
     "        pos.n += 1\n",
     "        pos.recent += (PlayerMove(pos.to_play, None),)\n",
@@ -784,7 +877,7 @@
     "        pos.ko = None\n",
     "        return pos\n",
     "\n",
-    "    def flip_playerturn(self, mutate=False):\n",
+    "    def flip_playerturn(self, mutate:bool=False): # modifies in place if `True`\n",
     "        \"\"\"Returns a copy of the `Position` object with `to_play`'s sign flipped.\"\"\"\n",
     "        pos = self if mutate else copy.deepcopy(self)\n",
     "        pos.ko = None\n",
@@ -794,7 +887,7 @@
     "    def get_liberties(self):\n",
     "        return self.lib_tracker.liberty_cache\n",
     "\n",
-    "    def play_move(self, c, color=None, mutate=False):\n",
+    "    def play_move(self, c, color=None, mutate:bool=False): # modifies in place if `True`\n",
     "        \"\"\"\n",
     "        Obeys [CGOS Rules of Play](http://www.yss-aya.com/cgos/): No suicides, Chinese/area scoring, Positional superko (this is approximated in this implementation).\n",
     "\n",
@@ -812,6 +905,7 @@
     "            pos = pos.pass_move(mutate=mutate)\n",
     "            return pos\n",
     "\n",
+    "        # only displays current player color, ignores color argument\n",
     "        if not self.is_move_legal(c):\n",
     "            raise IllegalMove(f\"{'Black' if self.to_play == BLACK else 'White'} move at {to_gtp(c)} is invalid: \\n{self}\") # coords.to_gtp\n",
     "\n",
@@ -890,6 +984,13 @@
     "            return f\"W+{abs(score):.1f}\"\n",
     "        else:\n",
     "            return 'DRAW'\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`Position.board_deltas` stores a rolling history of changes to the board. The previous 8 states are calculated by storing the last 7 deltas."
    ]
   },
   {
@@ -1045,7 +1146,11 @@
        "\n",
        "#### Position.pass_move\n",
        "\n",
-       ">      Position.pass_move (mutate=False)"
+       ">      Position.pass_move (mutate:bool=False)\n",
+       "\n",
+       "|    | **Type** | **Default** | **Details** |\n",
+       "| -- | -------- | ----------- | ----------- |\n",
+       "| mutate | bool | False | modifies in place if `True` |"
       ],
       "text/plain": [
        "<nbdev.showdoc.BasicMarkdownRenderer>"
@@ -1072,9 +1177,13 @@
        "\n",
        "#### Position.flip_playerturn\n",
        "\n",
-       ">      Position.flip_playerturn (mutate=False)\n",
+       ">      Position.flip_playerturn (mutate:bool=False)\n",
        "\n",
-       "Returns a copy of the `Position` object with `to_play`'s sign flipped."
+       "Returns a copy of the `Position` object with `to_play`'s sign flipped.\n",
+       "\n",
+       "|    | **Type** | **Default** | **Details** |\n",
+       "| -- | -------- | ----------- | ----------- |\n",
+       "| mutate | bool | False | modifies in place if `True` |"
       ],
       "text/plain": [
        "<nbdev.showdoc.BasicMarkdownRenderer>"
@@ -1128,9 +1237,15 @@
        "\n",
        "#### Position.play_move\n",
        "\n",
-       ">      Position.play_move (c, color=None, mutate=False)\n",
+       ">      Position.play_move (c, color=None, mutate:bool=False)\n",
        "\n",
-       "Obeys [CGOS Rules of Play](http://www.yss-aya.com/cgos/): No suicides, Chinese/area scoring, Positional superko (this is approximated in this implementation)."
+       "Obeys [CGOS Rules of Play](http://www.yss-aya.com/cgos/): No suicides, Chinese/area scoring, Positional superko (this is approximated in this implementation).\n",
+       "\n",
+       "|    | **Type** | **Default** | **Details** |\n",
+       "| -- | -------- | ----------- | ----------- |\n",
+       "| c |  |  |  |\n",
+       "| color | NoneType | None |  |\n",
+       "| mutate | bool | False | modifies in place if `True` |"
       ],
       "text/plain": [
        "<nbdev.showdoc.BasicMarkdownRenderer>"
@@ -1143,6 +1258,19 @@
    ],
    "source": [
     "show_doc(Position.play_move)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Returns a `Position` engine object.\n",
+    "\n",
+    "If coordinate `c` is `None`, the move is a pass. If `color` is `None`, the engine's current player is used. `mutate` will modify the engine object if `True`, otherwise it'll return a copy.\n",
+    "\n",
+    "The `color` parameter is only recommended for debugging.\n",
+    "\n",
+    "Concatenates changes to state onto `Position.board_deltas` and drops everything past the 7th delta."
    ]
   },
   {
@@ -1279,40 +1407,21 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Viewing the current board:"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n"
+     ]
+    },
+    {
      "data": {
       "text/plain": [
-       "array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],\n",
-       "       [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],\n",
-       "       [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],\n",
-       "       [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],\n",
-       "       [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],\n",
-       "       [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],\n",
-       "       [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],\n",
-       "       [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],\n",
-       "       [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],\n",
-       "       [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],\n",
-       "       [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],\n",
-       "       [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],\n",
-       "       [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],\n",
-       "       [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],\n",
-       "       [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],\n",
-       "       [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],\n",
-       "       [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],\n",
-       "       [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],\n",
-       "       [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]],\n",
-       "      dtype=int8)"
+       "<__main__.Position at 0x128548a30>"
       ]
      },
      "execution_count": null,
@@ -1321,50 +1430,37 @@
     }
    ],
    "source": [
-    "engine.board"
+    "c = (2,2)\n",
+    "print(engine.is_move_legal(c))\n",
+    "engine.play_move(c, mutate=True)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "Getting valid moves:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,\n",
-       "       1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,\n",
-       "       1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,\n",
-       "       1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,\n",
-       "       1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,\n",
-       "       1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,\n",
-       "       1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,\n",
-       "       1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,\n",
-       "       1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,\n",
-       "       1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,\n",
-       "       1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,\n",
-       "       1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,\n",
-       "       1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,\n",
-       "       1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,\n",
-       "       1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,\n",
-       "       1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,\n",
-       "       1, 1, 1, 1, 1, 1, 1, 1, 1, 1])"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "engine.all_legal_moves()"
    ]
   },
   {
@@ -1375,51 +1471,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "engine.to_play"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "Switch player turn:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "-1"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "engine = engine.flip_playerturn()\n",
-    "engine.to_play"
    ]
   },
   {
@@ -1430,50 +1485,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "engine.n"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "Check move history:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "()"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "engine.recent"
    ]
   },
   {
@@ -1493,45 +1508,32 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(-1, (2, 2))"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
-    "move = PlayerMove(WHITE, (2,2))\n",
-    "move.color, move.move"
+    "`Position` updates itself and now sets player `BLACK` (1) to play:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Playing a few more moves where `BLACK` will encircle `WHITE`'s first piece. We can rely on the engine to track who's turn it is."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "engine.is_move_legal(move.move)"
-   ]
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -1540,91 +1542,6 @@
     "*Work In Progress*\n",
     "\n",
     "..."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Go Coordinate Helpers"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This code is adapted from https://github.com/tensorflow/minigo/blob/master/coords.py, commit [ac169db](https://github.com/tensorflow/minigo/commit/ac169db7e002c152489615dd45f06c5ba7ee77fc), under the Apache 2.0 license."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "More than 19 entries are provided, for boards larger than 19x19."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#| export\n",
-    "_SGF_COLUMNS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'\n",
-    "_GTP_COLUMNS = 'ABCDEFGHJKLMNOPQRSTUVWXYZ'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#| export\n",
-    "def from_flat(flat):\n",
-    "    \"\"\"Converts from a flattened coordinate to a Go coordinate\"\"\"\n",
-    "    if flat == N * N: # go.N\n",
-    "        return None\n",
-    "    return divmod(flat, N)\n",
-    "\n",
-    "def to_flat(coord):\n",
-    "    \"\"\"Converts from a Go coordinate to a flattened coordinate.\"\"\"\n",
-    "    if coord is None:\n",
-    "        return N * N # go.N\n",
-    "    return N * coord[0] + coord[1]\n",
-    "\n",
-    "def from_sgf(sgfc):\n",
-    "    \"\"\"Converts from an SGF coordinate to a Go coordinate.\"\"\"\n",
-    "    if sgfc is None or sgfc == '' or (N <= 19 and sgfc == 'tt'): # go.N\n",
-    "        return None\n",
-    "    return _SGF_COLUMNS.index(sgfc[1]), _SGF_COLUMNS.index(sgfc[0])\n",
-    "\n",
-    "def to_sgf(coord):\n",
-    "    \"\"\"Converts from a Go coordinate to an SGF coordinate.\"\"\"\n",
-    "    if coord is None:\n",
-    "        return ''\n",
-    "    return _SGF_COLUMNS[coord[1]] + _SGF_COLUMNS[coord[0]]\n",
-    "\n",
-    "def from_gtp(gtpc):\n",
-    "    \"\"\"Converts from a GTP coordinate to a Go coordinate.\"\"\"\n",
-    "    gtpc = gtpc.upper()\n",
-    "    if gtpc == 'PASS':\n",
-    "        return None\n",
-    "    col = _GTP_COLUMNS.index(gtpc[0])\n",
-    "    row_from_bottom = int(gtpc[1:])\n",
-    "    return N - row_from_bottom, col # go.N\n",
-    "\n",
-    "def to_gtp(coord):\n",
-    "    \"\"\"Converts from a Go coordinate to a GTP coordinate.\"\"\"\n",
-    "    if coord is None:\n",
-    "        return 'pass'\n",
-    "    y,x = coord\n",
-    "    return f'{_GTP_COLUMNS[x]}{N-y}'\n"
    ]
   },
   {


### PR DESCRIPTION
`remove` may be a tuple, leading to a TypeError when `_update_liberties` attempts to subtract it from a frozenset. This PR recasts `remove` into a set.

Reproducing this error is as simple as:
```
engine = Position()
engine.play_move((2,2), mutate=True)
engine.play_move((2,1), mutate=True)
```

Unfortunately https://github.com/tensorflow/minigo is archived so this PR can't be upstreamed to fix their bug.